### PR TITLE
Declare `WP_CLI_ALLOW_ROOT` for the PHP container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       MYSQL_DATABASE: ${DB_DATABASE:-wordpress}
       MYSQL_USER: ${DB_USER:-wordpress}
       MYSQL_PASSWORD: ${DB_PASSWORD:-password}
+      WP_CLI_ALLOW_ROOT: true
       NEW_UID: 1000
       NEW_GID: 1000
     volumes:


### PR DESCRIPTION
Adding the `WP_CLI_ALLOW_ROOT` environment ensures WP-CLI can be used seamlessly within the container without passing `--allow-root`.

Although it's generally not advised to perform actions as root, within a docker container, this is generally the only user, doubly so in a developer container such as this, so simplifying the process is just a nice quality of life update.